### PR TITLE
🚨 fix inconsistent component state updates

### DIFF
--- a/src/base.tsx
+++ b/src/base.tsx
@@ -163,9 +163,9 @@ export default abstract class BaseComponent<
       } as S, callback);
     } else {
       // always set input value same as value
-      this.setState({
-        inputValue: this.toPrecisionAsStep(this.state.value),
-      }, callback);
+      this.setState(state => ({
+        inputValue: this.toPrecisionAsStep(state.value),
+      }), callback);
     }
     if (changed) {
       const { onChange } = this.props;


### PR DESCRIPTION
React component state updates using `setState` may asynchronously update `this.props` and `this.state`, thus it is not safe to use either of the two when calculating the new state passed to `setState`, and instead the callback-based variant should be used instead. ([details here](https://lgtm.com/rules/1819283066/)).

These were all found on LGTM.com, and there are [a couple of other alerts](https://lgtm.com/projects/g/react-component/m-input-number/alerts) for this project that would probably also be good to fix.

*(Full disclosure: I'm part of the team behind LGTM.com)*